### PR TITLE
Caching

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,47 @@
+use std::{path::{PathBuf, Path}, collections::HashMap, time::Instant};
+
+use image::RgbaImage;
+use log::debug;
+
+#[derive(Debug)]
+pub struct Cache {
+    pub data: HashMap<PathBuf, CachedImage>,
+    pub cache_size: usize,
+}
+
+#[derive(Debug)]
+pub struct CachedImage {
+    data: RgbaImage,
+    created: Instant,
+}
+
+
+impl Cache {
+    pub fn get(&self, path: &Path) -> Option<RgbaImage> {
+        self.data.get(path).map(|c| c.data.clone())
+    }
+
+    pub fn insert(&mut self, path: &Path, img: RgbaImage) {
+        self.data.insert(
+            path.into(),
+            CachedImage {
+                data: img,
+                created: std::time::Instant::now(),
+            },
+        );
+        if self.data.len() > self.cache_size {
+            debug!("Cache limit hit, deleting oldest");
+            let mut latest = std::time::Instant::now();
+            let mut key = PathBuf::new();
+
+            for (p, c) in &self.data {
+                if c.created < latest {
+                    latest = c.created;
+                    key = p.clone();
+                }
+            }
+
+            _ = self.data.remove(&key);
+        }
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -30,7 +30,6 @@ impl Cache {
             },
         );
         if self.data.len() > self.cache_size {
-            debug!("Cache limit hit, deleting oldest");
             let mut latest = std::time::Instant::now();
             let mut key = PathBuf::new();
 
@@ -40,6 +39,7 @@ impl Cache {
                     key = p.clone();
                 }
             }
+            debug!("Cache limit hit, deleting oldest: {}, {}s old", key.display(), latest.elapsed().as_secs_f32());
 
             _ = self.data.remove(&key);
         }

--- a/src/image_editing.rs
+++ b/src/image_editing.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 use crate::paint::PaintStroke;
 use crate::ui::EguiExt;
 
-use anyhow::{Result};
+use anyhow::Result;
 use evalexpr::*;
 use fast_image_resize as fr;
 use image::{imageops, RgbaImage};
@@ -490,45 +490,48 @@ impl ImageOperation {
                         ScaleFilter::Lanczos3 => fr::FilterType::Lanczos3,
                     };
 
-                    let width = NonZeroU32::new(img.width()).unwrap_or(anyhow::Context::context(NonZeroU32::new(1), "Can't create nonzero")?);
-                    let height =
-                        NonZeroU32::new(img.height()).unwrap_or(anyhow::Context::context(NonZeroU32::new(1), "Can't create nonzero")?);
+                    let width = NonZeroU32::new(img.width()).unwrap_or(anyhow::Context::context(
+                        NonZeroU32::new(1),
+                        "Can't create nonzero",
+                    )?);
+                    let height = NonZeroU32::new(img.height()).unwrap_or(anyhow::Context::context(
+                        NonZeroU32::new(1),
+                        "Can't create nonzero",
+                    )?);
                     let mut src_image = fr::Image::from_vec_u8(
                         width,
                         height,
                         img.clone().into_raw(),
                         fr::PixelType::U8x4,
-                    )
-                    ?;
+                    )?;
 
                     let mapper = fr::create_gamma_22_mapper();
-                    mapper
-                        .forward_map_inplace(&mut src_image.view_mut())
-                        ?;
+                    mapper.forward_map_inplace(&mut src_image.view_mut())?;
 
                     // Create container for data of destination image
-                    let dst_width =
-                        NonZeroU32::new(dimensions.0).unwrap_or(anyhow::Context::context(NonZeroU32::new(1), "Can't create nonzero")?);
-                    let dst_height =
-                        NonZeroU32::new(dimensions.1).unwrap_or(anyhow::Context::context(NonZeroU32::new(1), "Can't create nonzero")?);
+                    let dst_width = NonZeroU32::new(dimensions.0).unwrap_or(
+                        anyhow::Context::context(NonZeroU32::new(1), "Can't create nonzero")?,
+                    );
+                    let dst_height = NonZeroU32::new(dimensions.1).unwrap_or(
+                        anyhow::Context::context(NonZeroU32::new(1), "Can't create nonzero")?,
+                    );
                     let mut dst_image =
                         fr::Image::new(dst_width, dst_height, src_image.pixel_type());
 
                     let mut resizer = fr::Resizer::new(fr::ResizeAlg::Convolution(filter));
 
-                    resizer
-                        .resize(&src_image.view(), &mut dst_image.view_mut())
-                        ?;
+                    resizer.resize(&src_image.view(), &mut dst_image.view_mut())?;
 
-                    mapper
-                        .backward_map_inplace(&mut dst_image.view_mut())
-                        ?;
+                    mapper.backward_map_inplace(&mut dst_image.view_mut())?;
 
-                    *img = anyhow::Context::context(image::RgbaImage::from_raw(
-                        dimensions.0,
-                        dimensions.1,
-                        dst_image.into_vec(),
-                    ), "Can't create RgbaImage")?;
+                    *img = anyhow::Context::context(
+                        image::RgbaImage::from_raw(
+                            dimensions.0,
+                            dimensions.1,
+                            dst_image.into_vec(),
+                        ),
+                        "Can't create RgbaImage",
+                    )?;
                 }
             }
             Self::Rotate(angle) => {
@@ -574,7 +577,7 @@ impl ImageOperation {
     }
 
     /// Process a single pixel.
-    pub fn process_pixel(&self, p: &mut Vector4<f32>) -> Result<()>{
+    pub fn process_pixel(&self, p: &mut Vector4<f32>) -> Result<()> {
         match self {
             Self::Brightness(amt) => {
                 let amt = *amt as f32 / 255.;

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -40,7 +40,9 @@ pub fn launch() -> Result<(), Box<dyn Error>> {
         .get_matches_from(args);
 
     debug!("Completed argument parsing.");
-    let maybe_img_location = matches.get_one::<String>("INPUT").map(|arg| PathBuf::from(arg));
+    let maybe_img_location = matches
+        .get_one::<String>("INPUT")
+        .map(|arg| PathBuf::from(arg));
 
     if !matches.is_present("chainload") && maybe_img_location.is_none() {
         info!("Chainload not specified, and no input file present. Invoking mac hack.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use strum::IntoEnumIterator;
 
 pub mod settings;
 pub mod shortcuts;
+pub mod cache;
 use crate::shortcuts::InputEvent::*;
 mod utils;
 use utils::*;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,3 +1,4 @@
+use crate::utils::Frame;
 use anyhow::Result;
 use log::{error, info};
 use std::convert::TryInto;
@@ -5,7 +6,6 @@ use std::io::Read;
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::mpsc::Sender;
 use std::thread;
-use crate::utils::Frame;
 
 fn handle_client(mut stream: TcpStream, texture_sender: Sender<Frame>) -> Result<()> {
     let mut data = [0 as u8; 100000]; // using 50 byte buffer

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,7 +3,6 @@ use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 
-
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct PersistentSettings {
@@ -14,7 +13,9 @@ pub struct PersistentSettings {
     /// Keyboard map to actions
     pub shortcuts: Shortcuts,
     /// Do not reset view when receiving a new image
-    pub keep_view: bool
+    pub keep_view: bool,
+    /// How many images to keep in cache
+    pub max_cache: usize,
 }
 
 impl Default for PersistentSettings {
@@ -23,7 +24,8 @@ impl Default for PersistentSettings {
             accent_color: [255, 0, 75],
             vsync: true,
             shortcuts: Shortcuts::default_keys(),
-            keep_view: Default::default()
+            keep_view: Default::default(),
+            max_cache: 30,
         }
     }
 }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -196,10 +196,12 @@ pub fn key_pressed(app: &mut App, state: &mut OculanteState, command: InputEvent
         error!("Command not registered: '{:?}'. Inserting new.", command);
         // update missing shortcut
         if let Some(default_shortcut) = Shortcuts::default_keys().get(&command) {
-            state.persistent_settings.shortcuts.insert(command, default_shortcut.clone());
+            state
+                .persistent_settings
+                .shortcuts
+                .insert(command, default_shortcut.clone());
             _ = state.persistent_settings.save();
         }
-
     }
     false
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -295,7 +295,7 @@ pub fn settings_ui(app: &mut App, ctx: &Context, state: &mut OculanteState) {
             .anchor(Align2::CENTER_CENTER, [0.0, 0.0])
             .collapsible(false)
             .resizable(false)
-            .default_width(400.)
+            .default_width(600.)
             // .title_bar(false)
             .show(&ctx, |ui| {
 
@@ -320,6 +320,8 @@ pub fn settings_ui(app: &mut App, ctx: &Context, state: &mut OculanteState) {
                 });
 
 
+
+
                 if ui
                     .checkbox(&mut state.persistent_settings.vsync, "Enable vsync")
                     .on_hover_text(
@@ -329,6 +331,23 @@ pub fn settings_ui(app: &mut App, ctx: &Context, state: &mut OculanteState) {
                 {
                     _ = state.persistent_settings.save()
                 }
+
+
+                ui.horizontal(|ui| {
+                    ui.label("Number of image to cache");
+                    if ui
+                    .add(egui::DragValue::new(&mut state.persistent_settings.max_cache).clamp_range(0..=10000))
+
+                    .on_hover_text(
+                        "Keep this many images in memory for faster opening.",
+                    )
+                    .changed()
+                {
+                    state.player.cache.cache_size = state.persistent_settings.max_cache;
+                    _ = state.persistent_settings.save()
+                }
+                });
+
 
                 if ui
                 .checkbox(&mut state.persistent_settings.keep_view, "Do not reset image view")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -129,11 +129,22 @@ impl ExtendedImageInfo {
     }
 }
 
+#[derive(Debug, Default)]
+
+struct Cache {}
+
+impl Cache {
+    fn get(path: &Path) {
+        
+    }
+}
+
 #[derive(Debug)]
 pub struct Player {
     pub frame_sender: Sender<FrameCollection>,
     pub image_sender: Sender<Frame>,
     pub stop_sender: Sender<()>,
+    cache: Cache,
 }
 
 impl Player {
@@ -145,6 +156,7 @@ impl Player {
             frame_sender,
             image_sender,
             stop_sender,
+            cache: Cache::default(),
         }
     }
 
@@ -494,8 +506,12 @@ pub fn get_image_filenames_for_directory(folder_path: &Path) -> Option<Vec<PathB
 /// Find first valid image from the directory
 /// Assumes the given path is a directory and not a file
 pub fn find_first_image_in_directory(folder_path: &PathBuf) -> Option<PathBuf> {
-    if !folder_path.is_dir() {return None};
-    get_image_filenames_for_directory(folder_path).map(|x|x.first().cloned()).flatten()
+    if !folder_path.is_dir() {
+        return None;
+    };
+    get_image_filenames_for_directory(folder_path)
+        .map(|x| x.first().cloned())
+        .flatten()
 }
 
 /// Advance to the prev/next image

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -133,7 +133,7 @@ impl ExtendedImageInfo {
 
 pub struct Cache {
     data: HashMap<PathBuf, CachedImage>,
-    cache_size: usize,
+    pub cache_size: usize,
 }
 
 #[derive(Debug)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration};
 
 use exr::prelude as exrs;
 use exr::prelude::*;
@@ -34,6 +34,7 @@ use std::sync::mpsc::{Receiver, Sender};
 use strum::Display;
 use strum_macros::EnumIter;
 
+use crate::cache::Cache;
 use crate::image_editing::EditState;
 use crate::settings::PersistentSettings;
 
@@ -129,48 +130,7 @@ impl ExtendedImageInfo {
     }
 }
 
-#[derive(Debug)]
 
-pub struct Cache {
-    data: HashMap<PathBuf, CachedImage>,
-    pub cache_size: usize,
-}
-
-#[derive(Debug)]
-pub struct CachedImage {
-    data: RgbaImage,
-    created: Instant,
-}
-
-impl Cache {
-    fn get(&self, path: &Path) -> Option<RgbaImage> {
-        self.data.get(path).map(|c| c.data.clone())
-    }
-
-    pub fn insert(&mut self, path: &Path, img: RgbaImage) {
-        self.data.insert(
-            path.into(),
-            CachedImage {
-                data: img,
-                created: std::time::Instant::now(),
-            },
-        );
-        if self.data.len() > self.cache_size {
-            debug!("Cache limit hit, deleting oldest");
-            let mut latest = std::time::Instant::now();
-            let mut key = PathBuf::new();
-
-            for (p, c) in &self.data {
-                if c.created < latest {
-                    latest = c.created;
-                    key = p.clone();
-                }
-            }
-
-            _ = self.data.remove(&key);
-        }
-    }
-}
 
 #[derive(Debug)]
 pub struct Player {


### PR DESCRIPTION
This enables generic, configurable caching for still images (not gif). Images are indexed by their path, so this should work generically, even if the same image is dropped multiple times on the window.