### PR TITLE
PKGBUILD for publishing to AUR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 *.log
 Info.plist
+PKGBUILD
 paint/target
 shortcuts.txt
 perf.*

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,17 +1,26 @@
 # Maintainer: Johann Woelper <woelper@gmail.com>
 pkgname=oculante
-pkgver=0.6.57
+pkgver=0.6.58
 pkgrel=1
-makedepends=('rust' 'cargo')
+depends=('aom' 'libwebp' 'expat' 'freetype2' 'gtk3' 'cairo')
+makedepends=('rust' 'cargo' 'tar' 'nasm')
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 pkgdesc="A minimalistic image viewer with analysis and editing tools"
+url="https://github.com/woelper/oculante"
+source=("$pkgname-$pkgver.tar.gz::https://github.com/woelper/${pkgname}/archive/refs/tags/${pkgver}.tar.gz")
+sha512sums=('SKIP')
 license=('MIT')
 
 build() {
-    return 0
+    cd "$srcdir/$pkgname-$pkgver"
+    cargo build --locked --release
 }
 
 package() {
-    cd $srcdir
-    cargo install --root="$pkgdir" --git=https://github.com/woelper/oculante/
+    cd "$srcdir/$pkgname-$pkgver"
+    install -Dm755 target/release/oculante "${pkgdir}/usr/bin/${pkgname}"
+	install -Dm644 res/oculante.png "${pkgdir}/usr/share/icons/hicolor/128x128/apps/${pkgname}.png"
+	install -Dm644 res/oculante.desktop -t "${pkgdir}/usr/share/applications/${pkgname}.desktop"	
+	install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
+    install -Dm644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
 }

--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,21 @@ fn main() {
         )
         .unwrap();
 
+    // insert version into AUR PKGBUILD
+    let mut pkgbuild = String::new();
+    File::open("res/pkgbuild")
+        .unwrap()
+        .read_to_string(&mut pkgbuild)
+        .unwrap();
+    File::create("PKGBUILD")
+        .unwrap()
+        .write_all(
+            pkgbuild
+                .replace("$$VERSION$$", env!("CARGO_PKG_VERSION"))
+                .as_bytes(),
+        )
+        .unwrap();
+
     if cfg!(target_os = "windows") {
         let mut res = winres::WindowsResource::new();
         res.set_icon("icon.ico");

--- a/res/oculante.desktop
+++ b/res/oculante.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Oculante
+Comment=A no-nonsense hardware-accelerated image viewer
+GenericName=Image Viewer
+Keywords=image viewer;graphics;
+Exec=oculante %U
+Icon=oculante
+Terminal=false
+Categories=Graphics;
+Type=Application
+MimeType=image/bmp;image/gif;image/vnd.microsoft.icon;image/jpeg;image/png;image/pnm;image/avif;image/tiff;image/webp;image/svg+xml;image/exr;image/x-dcraw;image/x-nikon-nef;image/x-canon-cr2;image/x-adobe-dng;image/x-epson-erf;image/x-fuji-raf;image/x-sony-arw;image/x-sony-srf;image/x-sony-sr2;image/x-panasonic-raw;

--- a/res/pkgbuild
+++ b/res/pkgbuild
@@ -20,7 +20,7 @@ package() {
     cd "$srcdir/$pkgname-$pkgver"
     install -Dm755 target/release/oculante "${pkgdir}/usr/bin/${pkgname}"
 	install -Dm644 res/oculante.png "${pkgdir}/usr/share/icons/hicolor/128x128/apps/${pkgname}.png"
-	# install -Dm644 res/oculante.desktop -t "${pkgdir}/usr/share/applications/${pkgname}.desktop"	
+	install -Dm644 res/oculante.desktop -t "${pkgdir}/usr/share/applications/${pkgname}.desktop"	
 	install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
     install -Dm644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
 }

--- a/res/pkgbuild
+++ b/res/pkgbuild
@@ -2,7 +2,7 @@
 pkgname=oculante
 pkgver=$$VERSION$$
 pkgrel=1
-depends=('aom' 'libwebp')
+depends=('aom' 'libwebp' 'expat' 'freetype2' 'gtk3' 'cairo')
 makedepends=('rust' 'cargo' 'tar' 'nasm')
 arch=('i686' 'x86_64' 'armv6h' 'armv7h')
 pkgdesc="A minimalistic image viewer with analysis and editing tools"

--- a/res/pkgbuild
+++ b/res/pkgbuild
@@ -1,0 +1,26 @@
+# Maintainer: Johann Woelper <woelper@gmail.com>
+pkgname=oculante
+pkgver=$$VERSION$$
+pkgrel=1
+depends=('aom' 'libwebp')
+makedepends=('rust' 'cargo' 'tar' 'nasm')
+arch=('i686' 'x86_64' 'armv6h' 'armv7h')
+pkgdesc="A minimalistic image viewer with analysis and editing tools"
+url="https://github.com/woelper/oculante"
+source=("$pkgname-$pkgver.tar.gz::https://github.com/woelper/${pkgname}/archive/refs/tags/${pkgver}.tar.gz")
+sha512sums=('SKIP')
+license=('MIT')
+
+build() {
+    cd "$srcdir/$pkgname-$pkgver"
+    cargo build --locked --release
+}
+
+package() {
+    cd "$srcdir/$pkgname-$pkgver"
+    install -Dm755 target/release/oculante "${pkgdir}/usr/bin/${pkgname}"
+	install -Dm644 res/oculante.png "${pkgdir}/usr/share/icons/hicolor/128x128/apps/${pkgname}.png"
+	# install -Dm644 res/oculante.desktop -t "${pkgdir}/usr/share/applications/${pkgname}.desktop"	
+	install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
+    install -Dm644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
+}


### PR DESCRIPTION
This improves the pkgbuild suggested in #162 and adds a desktop entry for Oculante.

As is the PKGBUILD cannot be built with `makepkg` but that is _on purpose_. It tries to copy the desktop entry from the sources using the reference to the latest release but that file does not exist in any release _yet_. I have tested the script as well as I could with my system and I am quite confident that it will work fine. Commenting out the line that copies the desktop entry within the PKGBUILD causes it to work perfectly fine and this trick can be used temporarily to test it locally. It is quite similar to pkgbuilds of other Rust crates (e.g. [xplr](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=xplr-git), [eww](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=eww)) 

I went over [submission guidelines for AUR](https://wiki.archlinux.org/title/AUR_submission_guidelines) and as far as I can tell this format of pkgbuild is perfectly fine.

All that is left is to figure out how to publish it from CI. I have seen [some github actions for that](https://github.com/marketplace/actions/publish-aur-package) but I have no experience with github actions whatsoever and so I would rather touch them.