### PR TITLE
Adding gray value scaling

### DIFF
--- a/src/image_editing.rs
+++ b/src/image_editing.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::num::NonZeroU32;
-use std::ops::Index;
 use std::path::{Path, PathBuf};
 
 use crate::paint::PaintStroke;
@@ -21,7 +20,6 @@ use rayon::{iter::ParallelIterator, slice::ParallelSliceMut};
 use serde::{Deserialize, Serialize};
 
 use egui_phosphor::variants::regular::*;
-use tiff::encoder::TiffValue;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct EditState {

--- a/src/image_editing.rs
+++ b/src/image_editing.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::num::NonZeroU32;
+use std::ops::Index;
 use std::path::{Path, PathBuf};
 
 use crate::paint::PaintStroke;
@@ -20,6 +21,7 @@ use rayon::{iter::ParallelIterator, slice::ParallelSliceMut};
 use serde::{Deserialize, Serialize};
 
 use egui_phosphor::variants::regular::*;
+use tiff::encoder::TiffValue;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct EditState {
@@ -104,6 +106,7 @@ pub enum ImageOperation {
     GradientMap(Vec<GradientStop>),
     Exposure(i32),
     Equalize((i32, i32)),
+    ScaleImageMinMax,
     Mult([u8; 3]),
     Add([u8; 3]),
     Fill([u8; 4]),
@@ -120,7 +123,7 @@ pub enum ImageOperation {
     Invert,
     Blur(u8),
     MMult,
-    MDiv,
+    MDiv,    
     Resize {
         dimensions: (u32, u32),
         aspect: bool,
@@ -158,6 +161,7 @@ impl fmt::Display for ImageOperation {
             Self::GradientMap { .. } => write!(f, "🗠 Gradient Map"),
             Self::Expression(_) => write!(f, "{FUNCTION} Expression"),
             Self::MMult => write!(f, "✖ Multiply with alpha"),
+            Self::ScaleImageMinMax=> write!(f, "↹ Scale image min max"),
             Self::MDiv => write!(f, "➗ Divide by alpha"),
             Self::LUT(_) => write!(f, "{FILM_STRIP} Apply Color LUT"),
             // _ => write!(f, "Not implemented Display"),
@@ -176,6 +180,7 @@ impl ImageOperation {
             Self::Flip(_) => false,
             Self::ChromaticAberration(_) => false,
             Self::LUT(_) => false,
+            Self::ScaleImageMinMax => false,
             _ => true,
         }
     }
@@ -814,6 +819,46 @@ impl ImageOperation {
                 }
                 *img = image::imageops::flip_horizontal(img);
             }
+            Self::ScaleImageMinMax =>
+            {            
+                //Step 0: Get color channel min and max values   
+                let mut min = 255u8;                
+                let mut max = 0u8;                
+
+                img.chunks_mut(4).for_each(|px| {
+                    min = std::cmp::min(min, px[0]);
+                    min = std::cmp::min(min, px[1]);
+                    min = std::cmp::min(min, px[2]);
+
+                    max = std::cmp::max(max, px[0]);
+                    max = std::cmp::max(max, px[1]);
+                    max = std::cmp::max(max, px[2]);
+                });
+                let min_f = min as f64;
+                let max_f = max as f64;                
+                
+                
+                //Step 1: Don't do zero division
+                if min!=max {
+                    //Step 2: Create 8-Bit LUT
+                    let mut lut: [u8; 256] =[0u8;256];
+
+                    for n in min as usize..=max as usize {
+                        let g = n as f64;
+                        lut[n] = (255.0*(g-min_f)/(max_f-min_f)) as u8;
+                    }
+                    
+                    //Step 3: Apply 8-Bit LUT
+                    img
+                    
+                    .par_chunks_mut(4)
+                    .for_each(|px| {
+                        px[0] = lut[px[0] as usize];
+                        px[1] = lut[px[1] as usize];
+                        px[2] = lut[px[2] as usize];
+                    });       
+                }         
+            }
             Self::ChromaticAberration(amt) => {
                 let center = (img.width() as i32 / 2, img.height() as i32 / 2);
                 let img_c = img.clone();
@@ -1019,6 +1064,8 @@ pub fn builtin_luts() -> HashMap<String, Vec<u8>> {
     );
     luts
 }
+
+
 pub fn process_pixels(buffer: &mut RgbaImage, operators: &Vec<ImageOperation>) {
     // use pulp::Arch;
     // let arch = Arch::new();
@@ -1028,7 +1075,9 @@ pub fn process_pixels(buffer: &mut RgbaImage, operators: &Vec<ImageOperation>) {
     //             *x = 12 as u8;
     //         }
     //     });
-
+    
+   
+   
     buffer
         // .chunks_mut(4)
         .par_chunks_mut(4)

--- a/src/image_editing.rs
+++ b/src/image_editing.rs
@@ -159,7 +159,7 @@ impl fmt::Display for ImageOperation {
             Self::GradientMap { .. } => write!(f, "🗠 Gradient Map"),
             Self::Expression(_) => write!(f, "{FUNCTION} Expression"),
             Self::MMult => write!(f, "✖ Multiply with alpha"),
-            Self::ScaleImageMinMax=> write!(f, "↹ Scale image min max"),
+            Self::ScaleImageMinMax=> write!(f, "\u{2195} Scale image min max"),
             Self::MDiv => write!(f, "➗ Divide by alpha"),
             Self::LUT(_) => write!(f, "{FILM_STRIP} Apply Color LUT"),
             // _ => write!(f, "Not implemented Display"),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -699,6 +699,7 @@ pub fn edit_ui(app: &mut App, ctx: &Context, state: &mut OculanteState, gfx: &mu
                         ImageOperation::Desaturate(0),
                         ImageOperation::LUT("Lomography Redscale 100".into()),
                         ImageOperation::Equalize((0, 255)),
+                        ImageOperation::ScaleImageMinMax,
                         ImageOperation::Posterize(8),
                         ImageOperation::ChannelSwap((Channel::Red, Channel::Red)),
                         ImageOperation::Rotate(90),
@@ -708,7 +709,7 @@ pub fn edit_ui(app: &mut App, ctx: &Context, state: &mut OculanteState, gfx: &mu
                         ImageOperation::Fill([255, 255, 255, 255]),
                         ImageOperation::Blur(0),
                         ImageOperation::GradientMap(vec![GradientStop::new(0, [155,33,180]), GradientStop::new(128, [255,83,0]),GradientStop::new(255, [224,255,0])]),
-                        ImageOperation::MMult,
+                        ImageOperation::MMult,                        
                         ImageOperation::MDiv,
                         ImageOperation::Expression("r = 1.0".into()),
                         ImageOperation::Noise {


### PR DESCRIPTION
Added a functionality to scale the gray values displayed.
This is helpful for looking at images with a low value span, segmentation masks for example.