### PR TITLE
draw the first frame for egui

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -363,6 +363,8 @@ fn init(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins) -> OculanteSta
             .ok();
     }
 
+    gfx.render(&plugins.egui(|_| {}));
+
     state
 }
 


### PR DESCRIPTION
this seems to fix #285

i'm not familiar with egui, but i just tried to draw the first frame in init()

~i think the problem was that egui needs a draw call to be aware of the actual size of the surface considering the panels and everything~

maybe it's just an egui bug