### PR TITLE
Fix high cpu usage when started without images

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1011,13 +1011,12 @@ fn drawe(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins, state: &mut O
         }
 
         if state.reset_image {
-            let draw_area = ctx.available_rect();
-            let window_size = nalgebra::Vector2::new(
-                draw_area.width().min(app.window().width() as f32),
-                draw_area.height().min(app.window().height() as f32),
-            );
-
             if let Some(current_image) = &state.current_image {
+                let draw_area = ctx.available_rect();
+                let window_size = nalgebra::Vector2::new(
+                    draw_area.width().min(app.window().width() as f32),
+                    draw_area.height().min(app.window().height() as f32),
+                );
                 let img_size = current_image.size_vec();
                 state.image_geometry.scale = (window_size.x / img_size.x)
                     .min(window_size.y / img_size.y)
@@ -1030,8 +1029,8 @@ fn drawe(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins, state: &mut O
                 state.image_geometry.offset.y += draw_area.top();
                 debug!("Image has been reset.");
                 state.reset_image = false;
+                app.window().request_frame();
             }
-            app.window().request_frame();
         }
 
         // Settings come last, as they block keyboard grab (for hotkey assigment)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2047,16 +2047,14 @@ pub fn main_menu(ui: &mut Ui, state: &mut OculanteState, app: &mut App, gfx: &mu
                         .unwrap_or_default()
                 ));
             }
-        }
 
-        if !state.is_loaded {
-            if let Some(p) = &state.current_path {
+            if !state.is_loaded {
                 ui.horizontal(|ui| {
                     ui.add(egui::Spinner::default());
                     ui.label(format!("Loading {}", p.display()));
                 });
+                app.window().request_frame();
             }
-            app.window().request_frame();
         }
 
         drag_area(ui, state, app);


### PR DESCRIPTION
main_menu was requesting a frame for the loading spinner indefinitely