### PR TITLE
Add mouse wheel setting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use crate::image_editing::lossless_tx;
 use crate::scrubber::find_first_image_in_directory;
 use crate::settings::set_system_theme;
 use crate::settings::ColorTheme;
+use crate::settings::MouseWheelAction;
 use crate::shortcuts::InputEvent::*;
 mod utils;
 use utils::*;
@@ -603,7 +604,9 @@ fn event(app: &mut App, state: &mut OculanteState, evt: Event) {
         }
         Event::MouseWheel { delta_y, .. } => {
             if !state.pointer_over_ui {
-                if app.keyboard.ctrl() {
+                if app.keyboard.ctrl()
+                    ^ (state.persistent_settings.mouse_wheel_action == MouseWheelAction::NextPrev)
+                {
                     // Change image to next/prev
                     // - map scroll-down == next, as that's the natural scrolling direction
                     if delta_y > 0.0 {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,15 +18,6 @@ pub enum ColorTheme {
     System,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub enum MouseWheelAction {
-    /// Zoom in/out
-    #[default]
-    Zoom,
-    /// Next/Prev image
-    NextPrev,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct PersistentSettings {
@@ -67,7 +58,7 @@ pub struct PersistentSettings {
     pub fit_image_on_window_resize: bool,
     pub zoom_multiplier: f32,
     pub borderless: bool,
-    pub mouse_wheel_action: MouseWheelAction,
+    pub mouse_wheel_settings: MouseWheelSettings,
 }
 
 impl Default for PersistentSettings {
@@ -101,7 +92,7 @@ impl Default for PersistentSettings {
             fit_image_on_window_resize: false,
             zoom_multiplier: 1.0,
             borderless: false,
-            mouse_wheel_action: Default::default(),
+            mouse_wheel_settings: default_wheel_settings(),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,6 +18,15 @@ pub enum ColorTheme {
     System,
 }
 
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum MouseWheelAction {
+    /// Zoom in/out
+    #[default]
+    Zoom,
+    /// Next/Prev image
+    NextPrev,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct PersistentSettings {
@@ -58,6 +67,7 @@ pub struct PersistentSettings {
     pub fit_image_on_window_resize: bool,
     pub zoom_multiplier: f32,
     pub borderless: bool,
+    pub mouse_wheel_action: MouseWheelAction,
 }
 
 impl Default for PersistentSettings {
@@ -91,6 +101,7 @@ impl Default for PersistentSettings {
             fit_image_on_window_resize: false,
             zoom_multiplier: 1.0,
             borderless: false,
+            mouse_wheel_action: Default::default(),
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -631,6 +631,13 @@ pub fn settings_ui(app: &mut App, ctx: &Context, state: &mut OculanteState, gfx:
                     keybinding_ui(app, state, ui);
                 });
 
+                ui.collapsing("Mouse", |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Wheel:").on_hover_text("Unselected action is performed with ctrl+wheel");
+                        ui.radio_value(&mut state.persistent_settings.mouse_wheel_action, crate::settings::MouseWheelAction::Zoom, "Zoom");
+                        ui.radio_value(&mut state.persistent_settings.mouse_wheel_action, crate::settings::MouseWheelAction::NextPrev, "Next/Prev");
+                        });
+                });
             });
     state.settings_enabled = settings_enabled;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -757,6 +757,28 @@ pub fn next_image(state: &mut OculanteState) {
     }
 }
 
+pub fn zoom_image(state: &mut OculanteState, delta_y: f32) {
+    let divisor = if cfg!(macos) { 0.1 } else { 10. };
+    // Normal scaling
+    let delta = zoomratio(
+        ((delta_y / divisor) * state.persistent_settings.zoom_multiplier)
+            .max(-5.0)
+            .min(5.0),
+        state.image_geometry.scale,
+    );
+    let new_scale = state.image_geometry.scale + delta;
+    // limit scale
+    if new_scale > 0.01 && new_scale < 40. {
+        state.image_geometry.offset -= scale_pt(
+            state.image_geometry.offset,
+            state.cursor,
+            state.image_geometry.scale,
+            delta,
+        );
+        state.image_geometry.scale += delta;
+    }
+}
+
 /// Set the window title
 pub fn set_title(app: &mut App, state: &mut OculanteState) {
     let p = state.current_path.clone().unwrap_or_default();


### PR DESCRIPTION
Currently, mouse wheel and ctrl-wheel are statically assigned to zooming in/out and moving to next/prev image respectively.
With this PR, users will be able to swap these assignments.

## Changes
- add a new persistent setting `mouse_wheel_action`
- add `Mouse` section in the preferences UI for changing the setting (screenshot below)

![mouse_wheel_setting](https://github.com/woelper/oculante/assets/55069391/a9de9e1e-2c2d-48cf-8a95-c0f57739de62)

## New behavior
- With `Zoom` selected (default), mouse wheel works as zoom in/out and ctrl-wheel works as next/prev.
- With `Next/Prev` selected, mouse wheel works as next/prev and ctrl-wheel works as zoom in/out.

