### PR TITLE
Add cargo feature recent_images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ jpeg2k = { version = "0.7.0", optional = true, default-features = false, feature
 file-format = "0.25.0"
 
 [features]
-default = ["turbo", "avif_native", "file_open", "update", "notan/glsl-to-spirv", "j2k"]
+default = ["turbo", "avif_native", "file_open", "update", "notan/glsl-to-spirv", "j2k", "recent_images"]
 heif = ["libheif-rs"]
 avif_native = ["avif-decode"]
 dav1d = ["libavif-image"]
@@ -101,6 +101,7 @@ file_open = ["rfd"]
 turbo = ["turbojpeg"]
 update = ["self_update"]
 j2k = ["jpeg2k"]
+recent_images = []
 
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -820,6 +820,7 @@ fn drawe(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins, state: &mut O
             state.scrubber.wrap = state.persistent_settings.wrap_folder;
 
             // debug!("{:#?} from {}", &state.scrubber, p.display());
+            #[cfg(feature = "recent_images")]
             if !state.persistent_settings.recent_images.contains(p) {
                 state.persistent_settings.recent_images.insert(0, p.clone());
                 state.persistent_settings.recent_images.truncate(10);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -39,6 +39,7 @@ pub struct PersistentSettings {
     /// Whether to keep the image edit stack
     pub keep_edits: bool,
     pub favourite_images: HashSet<PathBuf>,
+    #[cfg(feature = "recent_images")]
     pub recent_images: Vec<PathBuf>,
     pub title_format: String,
     pub info_enabled: bool,
@@ -75,6 +76,7 @@ impl Default for PersistentSettings {
             wrap_folder: true,
             keep_edits: Default::default(),
             favourite_images: Default::default(),
+            #[cfg(feature = "recent_images")]
             recent_images: Default::default(),
             title_format: "{APP} | {VERSION} | {FULLPATH}".into(),
             info_enabled: Default::default(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,11 +8,15 @@ use crate::{
     shortcuts::{key_pressed, keypresses_as_string, lookup},
     utils::{
         clipboard_copy, disp_col, disp_col_norm, fix_exif, highlight_bleed, highlight_semitrans,
-        load_image_from_path, next_image, prev_image, send_extended_info, set_title, solo_channel,
-        toggle_fullscreen, unpremult, ColorChannel, ImageExt,
+        next_image, prev_image, send_extended_info, set_title, solo_channel, toggle_fullscreen,
+        unpremult, ColorChannel, ImageExt,
     },
     FrameSource,
 };
+
+#[cfg(feature = "recent_images")]
+use crate::utils::load_image_from_path;
+
 #[cfg(not(feature = "file_open"))]
 use crate::{filebrowser, SUPPORTED_EXTENSIONS};
 
@@ -2200,6 +2204,7 @@ pub fn draw_hamburger_menu(ui: &mut Ui, state: &mut OculanteState, app: &mut App
                 ui.close_menu();
             }
 
+            #[cfg(feature = "recent_images")]
             ui.menu_button("Recent", |ui| {
                 for r in &state.persistent_settings.recent_images.clone() {
                     if let Some(filename) = r.file_name() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -718,6 +718,7 @@ pub fn prev_image(state: &mut OculanteState) {
     }
 }
 
+#[cfg(feature = "recent_images")]
 pub fn load_image_from_path(p: &Path, state: &mut OculanteState) {
     state.is_loaded = false;
     state.player.load(p, state.message_channel.0.clone());


### PR DESCRIPTION
If you want to build a more privacy-focused version of the App you can now remove the cargo feature "recent_images" so they won't be stored in the config file.