### PR TITLE
Use writer_pretty for config.json formatting

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -143,7 +143,7 @@ fn save(s: &PersistentSettings) -> Result<()> {
     }
 
     let f = File::create(local_dir.join("config.json"))?;
-    Ok(serde_json::to_writer(f, s)?)
+    Ok(serde_json::to_writer_pretty(f, s)?)
 }
 
 pub fn set_system_theme(ctx: &Context) {


### PR DESCRIPTION
This change makes the formatting more readable as well as making editing easier on editors such as vim. This can be made even better with additional compact formatting but I think the existing implementation in serde is already a huge improvement for now!

Master:

![image](https://github.com/user-attachments/assets/ce6e63de-ec6f-4212-8a68-3aa4978030a3)

PR:

![image](https://github.com/user-attachments/assets/4e21d207-9f14-49ee-bb8d-5ca034701d25)
