### PR TITLE
Feat: tell jxl-oxide to decode to sRGB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ libblur = "0.13.5"
 egui-modal = "0.3.6"
 
 [features]
-default = ["turbo", "avif_native", "update", "notan/glsl-to-spirv", "j2k"]
+default = ["turbo", "avif_native", "update", "notan/glsl-to-spirv", "j2k", "jxlcms"]
 heif = ["libheif-rs"]
 avif_native = ["avif-decode"]
 dav1d = ["libavif-image"]
@@ -104,6 +104,7 @@ file_open = ["rfd"]
 turbo = ["turbojpeg"]
 update = ["self_update"]
 j2k = ["jpeg2k"]
+jxlcms = ["jxl-oxide/lcms2"]
 
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/image_loader.rs
+++ b/src/image_loader.rs
@@ -363,9 +363,13 @@ pub fn open_image(
             //TODO this needs to be a thread
 
             fn foo(img_location: &Path, frame_sender: Sender<Frame>) -> Result<()> {
-                let image = JxlImage::builder()
+                let mut image = JxlImage::builder()
                     .open(img_location)
                     .map_err(|e| anyhow!("{e}"))?;
+                //TODO: Disable when colormanagement support exists
+                let colorencoding = jxl_oxide::EnumColourEncoding::srgb(jxl_oxide::RenderingIntent::Perceptual);
+                image.request_color_encoding(colorencoding);
+
                 debug!("{:#?}", image.image_header().metadata);
                 let is_jxl_anim = image.image_header().metadata.animation.is_some();
                 let ticks_ms = image


### PR DESCRIPTION
This will make images with ICC profiles and otherwise HDR images be converted to sRGB. This should be reverted when oculante get's it's own colormanagement pipeline. 

Lcms2 I spun into it's own feature since it's not a native rust. but it is C and completely vendored so there should be no issues when compiling to various other platforms