### PR TITLE
Fixing: Application crashes if image changes size after edit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1042,6 +1042,13 @@ fn drawe(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins, state: &mut O
                 });
         }
 
+        if state.persistent_settings.edit_enabled
+            && !state.settings_enabled
+            && !state.persistent_settings.zen_mode
+        {
+            edit_ui(app, ctx, state, gfx);
+        }
+
         if state.persistent_settings.info_enabled
             && !state.settings_enabled
             && !state.persistent_settings.zen_mode
@@ -1049,12 +1056,7 @@ fn drawe(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins, state: &mut O
             info_ui(ctx, state, gfx);
         }
 
-        if state.persistent_settings.edit_enabled
-            && !state.settings_enabled
-            && !state.persistent_settings.zen_mode
-        {
-            edit_ui(app, ctx, state, gfx);
-        }
+        
 
         state.pointer_over_ui = ctx.is_pointer_over_area();
         // ("using pointer {}", ctx.is_using_pointer());

--- a/src/texture_wrapper.rs
+++ b/src/texture_wrapper.rs
@@ -29,9 +29,12 @@ pub struct TextureWrapperManager {
 
 impl TextureWrapperManager {
     pub fn set(&mut self, tex: Option<TexWrap>, gfx: &mut Graphics) {
-        if let Some(texture) = &mut self.current_texture {
+
+        let mut texture_taken: Option<TexWrap> = self.current_texture.take();           
+        if let Some(texture) = &mut texture_taken {            
             texture.unregister_textures(gfx);
         }
+
         self.current_texture = tex;
     }
 
@@ -165,6 +168,17 @@ impl TexWrap {
 
         let im_w = image.width();
         let im_h = image.height();
+
+        if im_w<1{
+            error!("Image width smaller than 1!");
+            return None;
+        }
+
+        if im_h<1{
+            error!("Image height smaller than 1!");
+            return None;
+        }
+
         let im_pixel_count = (im_w * im_h) as usize;
         let allow_mipmap = im_pixel_count < MAX_PIXEL_COUNT;
 
@@ -308,7 +322,8 @@ impl TexWrap {
         let x = xa.max(0).min(self.width() as i32 - 1);
         let y = ya.max(0).min(self.height() as i32 - 1);
 
-        let x_idx = x / self.col_translation as i32;
+        //Div by zero possible, never allow zero sized textures!
+        let x_idx = x / self.col_translation as i32; 
         let y_idx = y / self.row_translation as i32;
         let tex_idx =
             (y_idx * self.col_count as i32 + x_idx).min(self.texture_array.len() as i32 - 1);


### PR DESCRIPTION
- Rearranged function calls in draw function
- Safe unregistering egui textures with take() to supress race conditions
- Supressing creation of TextureWrapper with zero sized images
