### PR TITLE
Cache thumbnails under $XDG_CACHE_HOME

### DIFF
--- a/src/thumbnails.rs
+++ b/src/thumbnails.rs
@@ -76,7 +76,7 @@ pub fn path_to_id<P: AsRef<Path>>(path: P) -> PathBuf {
 }
 
 pub fn get_disk_cache_path() -> Result<PathBuf> {
-    Ok(dirs::data_local_dir()
+    Ok(dirs::cache_dir()
         .ok_or(anyhow!("Can't get local dir"))?
         .join("oculante")
         .join("thumbnails"))


### PR DESCRIPTION
Previously used `$XDG_DATA_HOME`, which is per [spec] for “important” user-specific data.

[spec]: https://specifications.freedesktop.org/basedir-spec/latest/
