### PR TITLE
fix(643): Launching with images in different dirs

### DIFF
--- a/src/scrubber.rs
+++ b/src/scrubber.rs
@@ -16,6 +16,7 @@ pub struct Scrubber {
     pub entries: Vec<PathBuf>,
     pub wrap: bool,
     pub direction: Direction,
+    pub fixed_paths: bool,
 }
 
 impl Scrubber {
@@ -27,6 +28,7 @@ impl Scrubber {
             entries,
             wrap: true,
             direction: Direction::Forward,
+            fixed_paths: false,
         }
     }
 


### PR DESCRIPTION
Closes: #643

Oculante replaces the current paths in its path scrubber when the directory changes. If the app is launched with images in two different directories, such as `oculante image.png a/b.png`, the aforementioned behavior clobbers the paths passed in.

---

I also removed a few clones. :smile_cat: 