### PR TITLE
fix(586): Compare list & scrubber mangles position

### DIFF
--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -1,4 +1,5 @@
 use crate::{
+    comparelist::CompareList,
     image_editing::EditState,
     scrubber::Scrubber,
     settings::{PersistentSettings, VolatileSettings},
@@ -10,13 +11,13 @@ use crate::{
 use egui_notify::Toasts;
 use image::DynamicImage;
 use nalgebra::Vector2;
-use notan::{egui::epaint::ahash::HashMap, prelude::Texture, AppState};
+use notan::{prelude::Texture, AppState};
 use std::{
     path::PathBuf,
     sync::mpsc::{self, Receiver, Sender},
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ImageGeometry {
     /// The scale of the displayed image
     pub scale: f32,
@@ -50,7 +51,7 @@ impl Message {
 #[derive(AppState)]
 pub struct OculanteState {
     pub image_geometry: ImageGeometry,
-    pub compare_list: HashMap<PathBuf, ImageGeometry>,
+    pub compare_list: CompareList,
     pub drag_enabled: bool,
     pub reset_image: bool,
     /// Is the image fully loaded?

--- a/src/comparelist.rs
+++ b/src/comparelist.rs
@@ -1,0 +1,109 @@
+use std::{
+    cmp,
+    path::{Path, PathBuf},
+};
+
+use crate::appstate::ImageGeometry;
+
+/// List of images to compare, sorted by [`PathBuf`].
+#[derive(Default)]
+pub struct CompareList {
+    index: usize,
+    list: Vec<CompareItem>,
+}
+
+impl CompareList {
+    /// Cycle through [`CompareItem`]s.
+    pub fn next(&mut self) -> Option<&CompareItem> {
+        (self.index + 1).checked_rem(self.list.len()).and_then(|i| {
+            self.index = i;
+            self.list.get(i)
+        })
+    }
+
+    /// Insert a unique [`CompareItem`].
+    pub fn insert(&mut self, item: CompareItem) {
+        // The internal vector is always sorted so we can always binary search.
+        // Binary search is slower than a hash table but still fast (log(n)).
+        // It also avoids sorting on each next call or draw.
+        if let Err(i) = self.list.binary_search(&item) {
+            // By inserting where the item is expected, sort order is preserved without needing to
+            // sort the slice again.
+            self.list.insert(i, item);
+            debug_assert!(
+                self.list.is_sorted(),
+                "Compare list should always be sorted"
+            );
+        }
+    }
+
+    /// Remove item by [`Path`] if it exists.
+    pub fn remove(&mut self, path: impl AsRef<Path>) -> Option<CompareItem> {
+        let path = path.as_ref();
+        self.list
+            .binary_search_by_key(&path, |item| &item.path)
+            .ok()
+            .map(|index| self.list.remove(index))
+    }
+
+    /// Get [`ImageGeometry`] by [`Path`] if exists.
+    pub fn get(&self, path: impl AsRef<Path>) -> Option<ImageGeometry> {
+        let path = path.as_ref();
+        self.list
+            .binary_search_by_key(&path, |item| &item.path)
+            .ok()
+            .and_then(|index| self.list.get(index).map(|item| item.geometry))
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.list.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.list.clear();
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &CompareItem> + use<'_> {
+        self.list.iter()
+    }
+}
+
+pub struct CompareItem {
+    pub path: PathBuf,
+    pub geometry: ImageGeometry,
+}
+
+impl CompareItem {
+    pub fn new(path: impl AsRef<Path>, geometry: ImageGeometry) -> Self {
+        let path = path.as_ref().to_path_buf();
+        Self { path, geometry }
+    }
+}
+
+impl PartialEq for CompareItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.path.eq(&other.path)
+    }
+}
+
+impl Eq for CompareItem {}
+
+impl PartialOrd for CompareItem {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        self.path.partial_cmp(&other.path)
+    }
+}
+
+impl Ord for CompareItem {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.path.cmp(&other.path)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod appstate;
 pub mod cache;
+pub mod comparelist;
 pub mod image_editing;
 pub mod image_loader;
 pub mod ktx2_loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use notan::egui::FontFamily;
 use notan::egui::FontTweak;
 use notan::egui::Id;
 use notan::prelude::*;
+use oculante::comparelist::CompareItem;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::mpsc;
@@ -412,7 +413,7 @@ fn process_events(app: &mut App, state: &mut OculanteState, evt: Event) {
                 limit_offset(app, state);
             }
             if key_pressed(app, state, CompareNext) {
-                compare_next(state);
+                compare_next(app, state);
             }
             if key_pressed(app, state, ResetView) {
                 state.reset_image = true
@@ -1289,4 +1290,17 @@ fn limit_offset(app: &mut App, state: &mut OculanteState) {
         .y
         .min(window_size.1 as f32)
         .max(-scaled_image_size.1);
+}
+
+// Handle [`CompareNext`] events
+fn compare_next(_app: &mut App, state: &mut OculanteState) {
+    if let Some(CompareItem { path, geometry }) = state.compare_list.next() {
+        state.is_loaded = false;
+        state.current_image = None;
+        state.player.load_advanced(
+            path,
+            Some(Frame::CompareResult(Default::default(), *geometry)),
+        );
+        state.current_path = Some(path.to_owned());
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -932,31 +932,6 @@ pub fn set_title(app: &mut App, state: &mut OculanteState) {
     app.window().set_title(&title_string);
 }
 
-pub fn compare_next(state: &mut OculanteState) {
-    if let Some(p) = &(state.current_path).clone() {
-        let mut compare_list: Vec<(PathBuf, ImageGeometry)> =
-            state.compare_list.clone().into_iter().collect();
-        compare_list.sort_by(|a, b| a.0.cmp(&b.0));
-
-        let index = compare_list.iter().position(|x| &x.0 == p).unwrap_or(0);
-        let index = if index + 1 < compare_list.len() {
-            index + 1
-        } else {
-            0
-        };
-
-        if let Some((path, geo)) = compare_list.get(index) {
-            state.is_loaded = false;
-            state.current_image = None;
-            state.player.load_advanced(
-                path,
-                Some(Frame::CompareResult(Default::default(), geo.clone())),
-            );
-            state.current_path = Some(path.clone());
-        }
-    }
-}
-
 pub fn fit(oldvalue: f32, oldmin: f32, oldmax: f32, newmin: f32, newmax: f32) -> f32 {
     (((oldvalue - oldmin) * (newmax - newmin)) / (oldmax - oldmin)) + newmin
 }


### PR DESCRIPTION
Using both the scrubber and the compare list to go to the next or previous image may clobber the current image position. I refactored the compare list to store its position as well as removed all clones for the list.

The result is that the scrubber and compare list maintain their own positions. I assume that both lists should have their own set of images (e.g. the scrubber may be open to ~/Pictures while the compare list has whatever images the user added). This patch does not fix that issue, but I can work on that in a separate PR if needed.