### PR TITLE
fix: Compiler warnings

### DIFF
--- a/src/ktx2_loader/image_texture_conversion.rs
+++ b/src/ktx2_loader/image_texture_conversion.rs
@@ -71,7 +71,7 @@ impl Image {
                     .map(|c| [f32::from_le_bytes(c[0..=3].try_into().unwrap())])
                     .flatten()
                     .map(|p| p.powf(2.2))
-                    .map(|p| (p.powf(1.0 / 2.2).max(0.0).min(1.0)))
+                    .map(|p| p.powf(1.0 / 2.2).max(0.0).min(1.0))
                     .collect::<Vec<_>>();
                 Rgba32FImage::from_vec(self.width() as u32, self.height() as u32, d)
                     .map(|i| DynamicImage::ImageRgba8(DynamicImage::ImageRgba32F(i).to_rgba8()))

--- a/src/texture_wrapper.rs
+++ b/src/texture_wrapper.rs
@@ -881,7 +881,7 @@ impl TexWrap {
         Ok(())
     }
 
-    fn get_dummy_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse {
+    fn get_dummy_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse<'_> {
         let tex_width_int = self.width() as i32;
         let tex_height_int = self.height() as i32;
 
@@ -898,7 +898,7 @@ impl TexWrap {
         }
     }
 
-    fn get_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse {
+    fn get_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse<'_> {
         let width_int = self.width() as i32;
         let height_int = self.height() as i32;
 


### PR DESCRIPTION
<details>
<summary>I get these compilers warnings without this patch.</summary>

```rust
warning: unnecessary parentheses around closure body
  --> src\ktx2_loader\image_texture_conversion.rs:74:30
   |
74 |                     .map(|p| (p.powf(1.0 / 2.2).max(0.0).min(1.0)))
   |                              ^                                   ^
   |
   = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
   |
74 -                     .map(|p| (p.powf(1.0 / 2.2).max(0.0).min(1.0)))
74 +                     .map(|p| p.powf(1.0 / 2.2).max(0.0).min(1.0))
   |

warning: unused variable: `decoder_opts`
  --> src\image_loader.rs:33:5
   |
33 |     decoder_opts: Option<DecoderSettings>,
   |     ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_decoder_opts`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: hiding a lifetime that's elided elsewhere is confusing
   --> src\texture_wrapper.rs:884:32
    |
884 |     fn get_dummy_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse {
    |                                ^^^^^                       --------------- the same lifetime is hidden here
    |                                |
    |                                the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
884 |     fn get_dummy_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse<'_> {
    |                                                                           ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> src\texture_wrapper.rs:901:26
    |
901 |     fn get_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse {
    |                          ^^^^^                       --------------- the same lifetime is hidden here
    |                          |
    |                          the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
901 |     fn get_texture_at_xy(&self, xa: i32, ya: i32) -> TextureResponse<'_> {
    |                                                                     ++++
warning: `oculante` (lib) generated 4 warnings (run `cargo fix --lib -p oculante` to apply 1 suggestion)
```
</details>
<details>
<summary>I get this compiler warning with this patch.</summary>

```rust
warning: unused variable: `decoder_opts`
  --> src\image_loader.rs:33:5
   |
33 |     decoder_opts: Option<DecoderSettings>,
   |     ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_decoder_opts`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: `oculante` (lib) generated 1 warning
```
</details>
on rustc 1.90.0-nightly (f8e355c23 2025-07-27).