### PR TITLE
Option to auto scale smaller images to fit frame

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1136,9 +1136,12 @@ fn drawe(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins, state: &mut O
                     draw_area.height().min(app.window().height() as f32),
                 );
                 let img_size = current_image.size_vec();
-                state.image_geometry.scale = (window_size.x / img_size.x)
-                    .min(window_size.y / img_size.y)
-                    .min(1.0);
+                let scaled_to_fit = window_size.component_div(&img_size).amin();
+                state.image_geometry.scale = if state.persistent_settings.auto_scale {
+                    scaled_to_fit
+                } else {
+                    scaled_to_fit.min(1.0)
+                };
                 state.image_geometry.offset =
                     window_size / 2.0 - (img_size * state.image_geometry.scale) / 2.0;
                 // offset by left UI elements

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -70,6 +70,8 @@ pub struct PersistentSettings {
     pub use_mipmaps: bool,
     pub fit_image_on_window_resize: bool,
     pub zoom_multiplier: f32,
+    /// Automatically scale/zoom the image to fit the frame
+    pub auto_scale: bool,
     pub borderless: bool,
     pub min_window_size: (u32, u32),
     pub experimental_features: bool,
@@ -105,6 +107,7 @@ impl Default for PersistentSettings {
             use_mipmaps: true,
             fit_image_on_window_resize: false,
             zoom_multiplier: 1.0,
+            auto_scale: false,
             borderless: false,
             min_window_size: (100, 100),
             experimental_features: false,

--- a/src/ui/settings_ui.rs
+++ b/src/ui/settings_ui.rs
@@ -175,6 +175,15 @@ pub fn settings_ui(app: &mut App, ctx: &Context, state: &mut OculanteState, _gfx
                                         ui.add(egui::DragValue::new(&mut state.persistent_settings.zoom_multiplier).clamp_range(0.05..=10.0).speed(0.01));
                                     }, ui);
 
+                                    configuration_item_ui(
+                                        "Auto scale to fit",
+                                        "Automatically scale images up to fit the window.",
+                                        |ui| {
+                                            ui.styled_checkbox(&mut state.persistent_settings.auto_scale, "");
+                                        },
+                                        ui,
+                                    );
+
                                     #[cfg(not(any(target_os = "netbsd", target_os = "freebsd")))]
                                     configuration_item_ui("Borderless mode", "Prevents drawing OS window decorations. A restart is required to take effect.", |ui| {
                                         ui.styled_checkbox(&mut state.persistent_settings.borderless, "");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -912,7 +912,15 @@ pub fn set_title(app: &mut App, state: &mut OculanteState) {
         .replacen("{APP}", env!("CARGO_PKG_NAME"), 10)
         .replacen("{VERSION}", env!("CARGO_PKG_VERSION"), 10)
         .replacen("{FULLPATH}", &format!("{}", p.display()), 10)
-        .replacen("{NUM}", &format!("{}/{}", state.scrubber.index + 1, state.scrubber.entries.len()), 10)
+        .replacen(
+            "{NUM}",
+            &format!(
+                "{}/{}",
+                state.scrubber.index + 1,
+                state.scrubber.entries.len()
+            ),
+            10,
+        )
         .replacen(
             "{FILENAME}",
             &p.file_name()


### PR DESCRIPTION
Currently, larger images automatically fit the window frame whereas smaller images are not scaled up. Smaller images take up only a fraction of the frame size. I usually have to zoom into smaller images to scale them up, but that becomes tedious for folders of many small images.

The default zoom option doesn't work as nice for mixed images sizes because images end up either zoomed in too much or not enough. What I want, and what this commit implements, is for images to always be scaled to the frame without any extra work.

I implemented this as an option that's disabled by default. It works for both smaller and larger images - in other words, it doesn't break images that are larger than the viewport. Those are still scaled correctly with this option enabled.