### PR TITLE
fix: typo in oculante.desktop MIME types

### DIFF
--- a/res/flathub/io.github.woelper.Oculante.desktop
+++ b/res/flathub/io.github.woelper.Oculante.desktop
@@ -8,4 +8,4 @@ Icon=io.github.woelper.Oculante
 Terminal=false
 Categories=Graphics;
 Type=Application
-MimeType=image/bmp;image/gif;image/vnd.microsoft.icon;image/jpeg;image/png;image/pnm;image/avif;image/tiff;image/webp;image/svg+xml;image/exr;image/x-dcraw;image/x-nikon-nef;image/x-canon-cr2;image/x-adobe-dng;image/x-epson-erf;image/x-fuji-raf;image/x-sony-arw;image/x-sony-srf;image/x-sony-sr2;image/x-panasonic-raw;
+MimeType=image/bmp;image/gif;image/vnd.microsoft.icon;image/jpeg;image/jp2;image/png;image/pnm;image/x-tga;image/jxl;image/avif;image/tiff;image/webp;image/octet-stream;application/dicom;application/vnd.adobe.photoshop;image/svg+xml;image/exr;image/x-exr;image/x-dcraw;image/x-nikon-nef;image/x-canon-cr2;image/x-adobe-dng;image/x-epson-erf;image/x-fuji-raf;image/x-sony-arw;image/x-sony-srf;image/x-sony-sr2;image/x-panasonic-raw;image/x-portable-pixmap;image/heic;image/x-qoi;

--- a/res/oculante.desktop
+++ b/res/oculante.desktop
@@ -8,4 +8,4 @@ Icon=oculante
 Terminal=false
 Categories=Graphics;
 Type=Application
-MimeType=image/bmp;image/gif;image/vnd.microsoft.icon;image/jpeg;image/jp2;image/png;image/pnm;image/x-tga;image/jxl;image/avif;image/tiff;image/webp;image/octet-stream;application/dicom;application/vnd.adobe.photoshop;image/svg+xml;image/exr;image/x-exr;image/x-dcraw;image/x-nikon-nef;image/x-canon-cr2;image/x-adobe-dng;image/x-epson-erf;image/x-fuji-raf;image/x-sony-arw;image/x-sony-srf;image/x-sony-sr2;image/x-panasonic-raw/x-portable-pixmap;image/heic;image/x-qoi;image/;
+MimeType=image/bmp;image/gif;image/vnd.microsoft.icon;image/jpeg;image/jp2;image/png;image/pnm;image/x-tga;image/jxl;image/avif;image/tiff;image/webp;image/octet-stream;application/dicom;application/vnd.adobe.photoshop;image/svg+xml;image/exr;image/x-exr;image/x-dcraw;image/x-nikon-nef;image/x-canon-cr2;image/x-adobe-dng;image/x-epson-erf;image/x-fuji-raf;image/x-sony-arw;image/x-sony-srf;image/x-sony-sr2;image/x-panasonic-raw;image/x-portable-pixmap;image/heic;image/x-qoi;


### PR DESCRIPTION
The .desktop file had two broken/unrecognized MIME types: `image/x-panasonic-raw/x-portable-pixmap` and `image/`. These should instead be `image/x-panasonic-raw` and `image/x-portable-pixmap` respectively.

Also bring the flathub .desktop file up to parity with the more updated oculante.desktop file.