### PR TITLE
Add Copy file path shortcut and right-click context menu on image

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -458,6 +458,15 @@ fn process_events(app: &mut App, state: &mut OculanteState, evt: Event) {
                 }
             }
 
+            if key_pressed(app, state, CopyFilePath) {
+                if let Some(p) = &state.current_path {
+                    clipboard_copy_text(&p.to_string_lossy());
+                    state.send_message_info("File path copied");
+                } else {
+                    state.send_message_warn("This image has no file path");
+                }
+            }
+
             if key_pressed(app, state, Paste) {
                 match clipboard_to_image() {
                     Ok(img) => {
@@ -1068,6 +1077,8 @@ fn drawe(app: &mut App, gfx: &mut Graphics, plugins: &mut Plugins, state: &mut O
         {
             toggle_fullscreen(app, state);
         }
+
+        image_context_menu(ctx, state);
 
         if state.new_image_loaded {
             ctx.memory_mut(|m| m.data.remove::<f64>(Id::new("resize_aspect_ratio")));

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -39,6 +39,7 @@ pub enum InputEvent {
     LosslessRotateRight,
     LosslessRotateLeft,
     Copy,
+    CopyFilePath,
     Paste,
     Browse,
     Quit,
@@ -138,7 +139,8 @@ impl ShortcutExt for Shortcuts {
             .add_keys(InputEvent::PanDown, &["LShift", "Down"])
             .add_keys(InputEvent::PanUp, &["LShift", "Up"])
             .add_keys(InputEvent::Paste, &["LControl", "V"])
-            .add_keys(InputEvent::Copy, &["LControl", "C"]);
+            .add_keys(InputEvent::Copy, &["LControl", "C"])
+            .add_keys(InputEvent::CopyFilePath, &["LControl", "LShift", "C"]);
         #[cfg(target_os = "macos")]
         {
             for (_, keys) in s.iter_mut() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -946,3 +946,81 @@ impl Modal {
             .memory_mut(|w| w.open_popup(self.id.clone().into()));
     }
 }
+
+/// Context menu shown when right-clicking the image area
+pub fn image_context_menu(ctx: &Context, state: &mut OculanteState) {
+    use crate::shortcuts::InputEvent;
+
+    let pos_id = Id::new("image_context_menu_pos");
+
+    // Open (or re-position) the menu on right click over the image area
+    if !state.pointer_over_ui
+        && !state.mouse_grab
+        && state.current_image.is_some()
+        && ctx.input(|r| r.pointer.secondary_clicked())
+    {
+        if let Some(pos) = ctx.input(|r| r.pointer.interact_pos()) {
+            ctx.data_mut(|d| d.insert_temp(pos_id, pos));
+        }
+    }
+
+    let Some(menu_pos) = ctx.data(|d| d.get_temp::<Pos2>(pos_id)) else {
+        return;
+    };
+
+    let mut close_menu = false;
+
+    let area = egui::Area::new(Id::new("image_context_menu"))
+        .order(Order::Foreground)
+        .constrain(true)
+        .fixed_pos(menu_pos)
+        .show(ctx, |ui| {
+            egui::Frame::menu(ui.style()).show(ui, |ui| {
+                ui.vertical(|ui| {
+                    if let Some(img) = &state.current_image {
+                        if ui
+                            .styled_button(format!("{COPY} Copy image"))
+                            .on_hover_text(format!(
+                                "Copy image to clipboard ({})",
+                                lookup(&state.persistent_settings.shortcuts, &InputEvent::Copy)
+                            ))
+                            .clicked()
+                        {
+                            clipboard_copy(img);
+                            state.send_message_info("Image copied");
+                            close_menu = true;
+                        }
+                    }
+
+                    if let Some(path) = &state.current_path {
+                        if ui
+                            .styled_button(format!("{FILE} Copy file path"))
+                            .on_hover_text(format!(
+                                "Copy file path to clipboard ({})",
+                                lookup(
+                                    &state.persistent_settings.shortcuts,
+                                    &InputEvent::CopyFilePath
+                                )
+                            ))
+                            .clicked()
+                        {
+                            clipboard_copy_text(&path.to_string_lossy());
+                            state.send_message_info("File path copied");
+                            close_menu = true;
+                        }
+                    }
+                });
+            });
+        });
+
+    // Close on action, click outside or escape
+    let clicked_outside = ctx.input(|r| r.pointer.any_pressed())
+        && !area
+            .response
+            .rect
+            .contains(ctx.input(|r| r.pointer.interact_pos()).unwrap_or_default());
+
+    if close_menu || clicked_outside || ctx.input(|r| r.key_pressed(Key::Escape)) {
+        ctx.data_mut(|d| d.remove::<Pos2>(pos_id));
+    }
+}

--- a/src/ui/top_bar.rs
+++ b/src/ui/top_bar.rs
@@ -354,6 +354,20 @@ pub fn draw_hamburger_menu(ui: &mut Ui, state: &mut OculanteState, app: &mut App
                 }
             }
 
+            let copy_path_pressed = key_pressed(app, state, CopyFilePath);
+            if let Some(path) = &state.current_path {
+                if ui
+                    .styled_button(format!("{FILE} Copy path"))
+                    .on_hover_text("Copy file path to clipboard")
+                    .clicked()
+                    || copy_path_pressed
+                {
+                    clipboard_copy_text(&path.to_string_lossy());
+                    state.send_message_info("File path copied");
+                    ui.close_menu();
+                }
+            }
+
             if ui
                 .styled_button(format!("{CLIPBOARD} Paste"))
                 .on_hover_text("Paste image from clipboard")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -839,6 +839,12 @@ pub fn clipboard_copy(img: &DynamicImage) {
     }
 }
 
+pub fn clipboard_copy_text(text: &str) {
+    if let Ok(clipboard) = &mut Clipboard::new() {
+        let _ = clipboard.set_text(text);
+    }
+}
+
 pub fn load_image_from_path(p: &Path, state: &mut OculanteState) {
     state.is_loaded = false;
     state.player.load(p);


### PR DESCRIPTION
## What

- **New shortcut `CopyFilePath`** (default <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd>, <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> on macOS) that copies the current image''s file path to the clipboard. It appears automatically in the Preferences keybinding editor, and existing users'' saved shortcut maps self-heal via the existing `key_pressed()` default-insertion mechanism.
- **Right-click context menu on the image area** offering *Copy image* and *Copy file path*. Uses the existing `styled_button` look & feel, honors the `pointer_over_ui` / `mouse_grab` guards, and closes on action, outside click, or <kbd>Esc</kbd>. Hover text shows the bound shortcuts.
- **"Copy path" entry in the hamburger menu** next to the existing *Copy*, following the same pattern.
- Small `clipboard_copy_text()` helper in `utils.rs` (arboard `set_text`).

## Why

Copying an image to the clipboard already exists as a menu entry and shortcut; copying the file's path is a frequent companion need (sharing paths in chats, terminals, scripts). A context menu on the image itself also makes both actions discoverable where users expect them.

## Notes

- No new dependencies.
- Ctrl+Shift+C does not collide with `Copy` (Ctrl+C), `CompareNext` (Shift+C) or the `C` channel key since `key_pressed()` matches on the exact number of held keys.
- Tested on Windows 11 (cargo check/build with default features, manual run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)